### PR TITLE
Allow for multiple players on the same IP

### DIFF
--- a/source/server/sv_main.cpp
+++ b/source/server/sv_main.cpp
@@ -206,18 +206,21 @@ static void SV_ReadPackets() {
 				if( cl->edict && ( cl->edict->r.svflags & SVF_FAKECLIENT ) ) {
 					continue;
 				}
-				if( !NET_CompareBaseAddress( &address, &cl->netchan.remoteAddress ) ) {
+				// originally compare base address, todo conduct testing to verify that this doesn't break everything
+				// if it does, then match msg -> client a smarter way!
+				if( !NET_CompareAddress( &address, &cl->netchan.remoteAddress ) ) {
 					continue;
 				}
 				if( cl->netchan.game_port != game_port ) {
 					continue;
 				}
 
-				addr_port = NET_GetAddressPort( &address );
-				if( NET_GetAddressPort( &cl->netchan.remoteAddress ) != addr_port ) {
-					Com_Printf( "SV_ReadPackets: fixing up a translated port\n" );
-					NET_SetAddressPort( &cl->netchan.remoteAddress, addr_port );
-				}
+				// NOTE(scoot) see above
+				// addr_port = NET_GetAddressPort( &address );
+				// if( NET_GetAddressPort( &cl->netchan.remoteAddress ) != addr_port ) {
+				// 	Com_Printf( "SV_ReadPackets: fixing up a translated port\n" );
+				// 	NET_SetAddressPort( &cl->netchan.remoteAddress, addr_port );
+				// }
 
 				if( SV_ProcessPacket( &cl->netchan, &msg ) ) { // this is a valid, sequenced packet, so process it
 					cl->lastPacketReceivedTime = svs.realtime;

--- a/source/server/sv_oob.cpp
+++ b/source/server/sv_oob.cpp
@@ -520,8 +520,7 @@ static void SVC_DirectConnect( const socket_t *socket, const netadr_t *address )
 		if( cl->state == CS_FREE ) {
 			continue;
 		}
-		if( NET_CompareAddress( address, &cl->netchan.remoteAddress ) ||
-			( NET_CompareBaseAddress( address, &cl->netchan.remoteAddress ) && cl->netchan.game_port == game_port ) ) {
+		if( NET_CompareAddress( address, &cl->netchan.remoteAddress ) ) {
 			if( !NET_IsLocalAddress( address ) &&
 				( time - cl->lastconnect ) < (unsigned)( sv_reconnectlimit->integer * 1000 ) ) {
 				Com_DPrintf( "%s:reconnect rejected : too soon\n", NET_AddressToString( address ) );


### PR DESCRIPTION
Previously, an overzealous NAT workaround pretended that any activity
from other ports on the same IP was from the first client to connect
from that IP.

This is only a temporary workaround, a more bulletproof fix would
associate clients by a more robust means than (ip, port).
Let me know if you think that pursuing that path is worthwhile, or
if this fix is good enough.