### PR TITLE
change player->alive to use G_IsDead() instead of checking deadflag

### DIFF
--- a/source/game/g_frame.cpp
+++ b/source/game/g_frame.cpp
@@ -160,7 +160,7 @@ static void G_UpdateClientScoreboard( edict_t * ent ) {
 	player->kills = stats->kills;
 	player->ready = stats->ready;
 	player->carrier = ent->r.client->ps.carrying_bomb;
-	player->alive = ent->deadflag != DEAD_DEAD;
+	player->alive = !G_IsDead( ent );
 }
 
 /*


### PR DESCRIPTION
obani mentioned this would be a good starter commit and that the scoreboard code should move away from using deadflag to check if a  player was alive.