### PR TITLE
Debugging

### DIFF
--- a/ggbuild/gen_ninja.lua
+++ b/ggbuild/gen_ninja.lua
@@ -14,7 +14,7 @@ configs[ "windows" ] = {
 }
 
 configs[ "windows-debug" ] = {
-	cxxflags = "/MTd /Z7",
+	cxxflags = "/MTd /Z7 /FC",
 	ldflags = "/DEBUG",
 }
 configs[ "windows-release" ] = {

--- a/vs2019.bat
+++ b/vs2019.bat
@@ -1,3 +1,3 @@
-if not defined INCLUDE call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64
+@if not defined INCLUDE call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86_amd64
 ggbuild\lua.exe make.lua > build.ninja
 ggbuild\ninja.exe


### PR DESCRIPTION
- Include full paths in diagnostic messages for debug builds, this makes it easier to write problem matchers in VS Code.
- Mute batch `IF` command in output