### PR TITLE
fix game menu defocusing

### DIFF
--- a/source/client/cl_menus.cpp
+++ b/source/client/cl_menus.cpp
@@ -1239,6 +1239,8 @@ static void GameMenu() {
 
 		Settings();
 	}
+	
+	ImGui::SetWindowFocus();
 
 	if( ImGui::Hotkey( K_ESCAPE ) || should_close ) {
 		uistate = UIState_Hidden;


### PR DESCRIPTION
fixed weird menu behaviour (where it would defocus the game menu after switching out of the game window then back in)