### PR TITLE
fix double UI_ShowMainMenu call

### DIFF
--- a/source/client/cl_main.cpp
+++ b/source/client/cl_main.cpp
@@ -1160,8 +1160,6 @@ void CL_Init() {
 
 	CL_InitImGui();
 	UI_Init();
-
-	UI_ShowMainMenu();
 }
 
 void CL_Shutdown() {


### PR DESCRIPTION
UI_ShowMainMenu() is called inside UI_Init(), so in CL_Init it was called twice. This caused inconsistent freezing and segfaults on linux, in particular, it was because RefreshServerBrowser was called twice